### PR TITLE
Fix package reinstalling issue in Puppet EI v6.4.0

### DIFF
--- a/modules/ei_analytics_dashboard/manifests/init.pp
+++ b/modules/ei_analytics_dashboard/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_analytics_dashboard inherits ei_analytics_dashboard::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -44,6 +46,7 @@ class ei_analytics_dashboard inherits ei_analytics_dashboard::params {
     home   => "/home/${user}",
     system => true,
   }
+
   # Ensure the installation directory is available
   file { "/opt/${product}":
     ensure => 'directory',
@@ -52,18 +55,18 @@ class ei_analytics_dashboard inherits ei_analytics_dashboard::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_analytics_worker/manifests/init.pp
+++ b/modules/ei_analytics_worker/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_analytics_worker inherits ei_analytics_worker::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -44,6 +46,7 @@ class ei_analytics_worker inherits ei_analytics_worker::params {
     home   => "/home/${user}",
     system => true,
   }
+
   # Ensure the installation directory is available
   file { "/opt/${product}":
     ensure => 'directory',
@@ -52,18 +55,18 @@ class ei_analytics_worker inherits ei_analytics_worker::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_bps/manifests/init.pp
+++ b/modules/ei_bps/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_bps inherits ei_bps::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -53,18 +55,18 @@ class ei_bps inherits ei_bps::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_broker/manifests/init.pp
+++ b/modules/ei_broker/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_broker inherits ei_broker::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -53,18 +55,18 @@ class ei_broker inherits ei_broker::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_integrator/manifests/init.pp
+++ b/modules/ei_integrator/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_integrator inherits ei_integrator::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -53,19 +55,19 @@ class ei_integrator inherits ei_integrator::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_micro_integrator/manifests/init.pp
+++ b/modules/ei_micro_integrator/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_micro_integrator inherits ei_micro_integrator::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -53,18 +55,18 @@ class ei_micro_integrator inherits ei_micro_integrator::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/ei_msf4j/manifests/init.pp
+++ b/modules/ei_msf4j/manifests/init.pp
@@ -19,14 +19,16 @@
 class ei_msf4j inherits ei_msf4j::params {
 
   if $::osfamily == 'redhat' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.rpm"
-    $installer_provider = 'rpm'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
     $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $ei_package = "wso2ei-linux-installer-x64-${product_version}.deb"
-    $installer_provider = 'dpkg'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
     $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -53,18 +55,18 @@ class ei_msf4j inherits ei_msf4j::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${ei_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${ei_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 Enterprise Integrator
-  package { $product:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${ei_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group


### PR DESCRIPTION
## Purpose
> To resolve https://github.com/wso2/puppet-ei/issues/23

## Goals
> Ensure Puppet 5 EI 6.4.0 runs without an issue.

## Approach
>  Change package installers to apt and yum

## Test environment
> Ubuntu 18.04 ( Bionic Beaver) with puppet 5.4.0
> CentOS 7 with puppet 5.5.6
 