### PR TITLE
Move product distributions outside modules

### DIFF
--- a/modules/ei_analytics_dashboard/manifests/init.pp
+++ b/modules/ei_analytics_dashboard/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_analytics_dashboard inherits ei_analytics_dashboard::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_analytics_dashboard_master/manifests/init.pp
+++ b/modules/ei_analytics_dashboard_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_analytics_dashboard_master inherits ei_analytics_dashboard_master::para
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_analytics_worker/manifests/init.pp
+++ b/modules/ei_analytics_worker/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_analytics_worker inherits ei_analytics_worker::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_analytics_worker_master/manifests/init.pp
+++ b/modules/ei_analytics_worker_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_analytics_worker_master inherits ei_analytics_worker_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_bps/manifests/init.pp
+++ b/modules/ei_bps/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_bps inherits ei_bps::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_bps_master/manifests/init.pp
+++ b/modules/ei_bps_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_bps_master inherits ei_bps_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_broker/manifests/init.pp
+++ b/modules/ei_broker/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_broker inherits ei_broker::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_broker_master/manifests/init.pp
+++ b/modules/ei_broker_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_broker_master inherits ei_broker_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_integrator/manifests/init.pp
+++ b/modules/ei_integrator/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_integrator inherits ei_integrator::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_integrator_master/manifests/init.pp
+++ b/modules/ei_integrator_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_integrator_master inherits ei_integrator_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_micro_integrator/manifests/init.pp
+++ b/modules/ei_micro_integrator/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_micro_integrator inherits ei_micro_integrator::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_micro_integrator_master/manifests/init.pp
+++ b/modules/ei_micro_integrator_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_micro_integrator_master inherits ei_micro_integrator_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/ei_msf4j/manifests/init.pp
+++ b/modules/ei_msf4j/manifests/init.pp
@@ -46,7 +46,7 @@ class ei_msf4j inherits ei_msf4j::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/ei_msf4j_master/manifests/init.pp
+++ b/modules/ei_msf4j_master/manifests/init.pp
@@ -30,7 +30,7 @@ class ei_msf4j_master inherits ei_msf4j_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-ei/issues/28

## Goals
> The location of distributions have been moved outside from the `<puppet_env>/modules/<profile>/files` directory to `<puppet_env>/modules/distributions/files`

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04