### PR TITLE
Stop broker, BPS, and analytics servers by obtaining the correct PIDs

### DIFF
--- a/modules/ei_analytics_dashboard/manifests/init.pp
+++ b/modules/ei_analytics_dashboard/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_analytics_dashboard inherits ei_analytics_dashboard::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/analytics/wso2/dashboard/runtime.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/analytics/wso2/dashboard/runtime.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/ei_analytics_worker/manifests/init.pp
+++ b/modules/ei_analytics_worker/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_analytics_worker inherits ei_analytics_worker::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/analytics/wso2/worker/runtime.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/analytics/wso2/worker/runtime.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/ei_bps/manifests/init.pp
+++ b/modules/ei_bps/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_bps inherits ei_bps::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/wso2carbon.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/wso2carbon.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/ei_bps_master/manifests/params.pp
+++ b/modules/ei_bps_master/manifests/params.pp
@@ -22,7 +22,6 @@ class ei_bps_master::params inherits common::params {
   $product = 'wso2ei'
   $product_version = '6.4.0'
   $profile = 'business-process'
-  $hostname = 'localhost'
 
   # Define the template
   $template_list = [

--- a/modules/ei_broker/manifests/init.pp
+++ b/modules/ei_broker/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_broker inherits ei_broker::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/wso2carbon.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/wso2carbon.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/ei_micro_integrator/manifests/init.pp
+++ b/modules/ei_micro_integrator/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_micro_integrator inherits ei_micro_integrator::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/wso2carbon.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/wso2carbon.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/ei_msf4j/manifests/init.pp
+++ b/modules/ei_msf4j/manifests/init.pp
@@ -88,9 +88,9 @@ class ei_msf4j inherits ei_msf4j::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/wso2carbon.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/wso2carbon.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-ei/issues/36

## Goals
> Kill EI profiles by obtaining the PIDs from the proper files.

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04