### PR TITLE
Stop server using service name

### DIFF
--- a/modules/ei_common/manifests/init.pp
+++ b/modules/ei_common/manifests/init.pp
@@ -90,11 +90,11 @@ class ei_common inherits ei_common::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "systemctl stop ${profile}",
+    command     => "systemctl stop ${wso2_service_name}",
     path        => [ '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/' ],
     tries       => $try_count,
     try_sleep   => $try_sleep,
-    onlyif      => "/usr/bin/test -f /etc/systemd/system/${profile}.service",
+    onlyif      => "/usr/bin/test -f /etc/systemd/system/${wso2_service_name}.service",
     subscribe   => File["wso2-binary"],
     refreshonly => true,
   }


### PR DESCRIPTION
## Goals
> Stop server using service name

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04