### PR TITLE
Fix systemd file syntax error

### DIFF
--- a/modules/ei_common/templates/carbon.service.erb
+++ b/modules/ei_common/templates/carbon.service.erb
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 ExecStart=<%= @server_script_path %> start
 ExecStop=<%= @server_script_path %> stop
-ExecRestart=<%= @server_script_path %> restart
+ExecReload=<%= @server_script_path %> restart
 PIDFile=<%= @pid_file_path %>
 User=<%= @user %>
 Group=<%= @user_group %>


### PR DESCRIPTION
## Purpose
Resolves #70

## Goals
Fixes the syntax error in the systemd service file

## Documentation
https://www.freedesktop.org/software/systemd/man/systemd.service.html

## Test environment
Ubuntu 16.04
